### PR TITLE
Implementa função filtrar_pares e adiciona no main.rs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,23 @@
+fn filtrar_pares(vetor: &mut Vec<i64>) {
+    let mut pares = Vec::new();
+
+    for valor in vetor.iter() {
+        if valor % 2 == 0 && !pares.contains(valor) {
+            pares.push(*valor);
+        } 
+    }
+
+    *vetor = pares;
+}
+
 fn executar_estrategia(mut lista: Vec<i64>, estrategia: fn(&mut Vec<i64>)) {
     estrategia(&mut lista);
     println!("Resultado: {:?}", lista);
 }
 
 fn main() {
-    let numeros = vec![5, 2, 8, 5, 2, 9, 1, 0, 4, 4];
+    let numeros = vec![5, 5, 1, 0, 9, 8, 6, 2, 8, 5, 2, 9, 1, 0, 4, 4];
     println!("Lista original: {:?}", numeros);
 
+    executar_estrategia(numeros, filtrar_pares);
 }


### PR DESCRIPTION
# Implementa função `filtrar_pares`

Basicamente, a função de filtrar pares recebe um parâmetro vetor, que é uma referência mutável para o vetor criado na main. Dentro da função, criei a variável pares que vai receber apenas os números pares uma única vez dentro do laço que itera por todo o vetor principal. Após o laço ser finalizado, é possível garantir que pares contém apenas os valores mencionados, uma única vez. Fazemos o ponteiro para o vetor principal receber esse outro vetor pares, para que o vetor principal fique atualizado.

## 📌 Exemplo de uso

```rust
let numeros = vec![5, 5, 1, 0, 9, 8, 6, 2, 8, 5, 2, 9, 1, 0, 4, 4];
    println!("Lista original: {:?}", numeros);

    executar_estrategia(numeros, filtrar_pares);
// Agora `numeros` será: [0, 8, 6, 2, 4]
